### PR TITLE
fix: maven-assembly-plugin 2.6 doesn't work with Java > 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# java project
+target/
+.classpath
+.project
+.settings/

--- a/lambda/custom/pom.xml
+++ b/lambda/custom/pom.xml
@@ -39,10 +39,19 @@
         <sourceDirectory>src</sourceDirectory>
         <pluginManagement>
             <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>1.8</source>
                         <target>1.8</target>


### PR DESCRIPTION
Coordinated with https://github.com/alexa/ask-cli/pull/373.
